### PR TITLE
lazy load of vtk module (for menpo3d without X11)

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -18,7 +18,7 @@ requirements:
 test:
   requires:
   - nose
-  - mock
+  - mock 1.0.1
 
   imports:
   - menpo3d

--- a/menpo3d/vtkutils.py
+++ b/menpo3d/vtkutils.py
@@ -1,7 +1,4 @@
 import numpy as np
-import vtk
-from vtk.util.numpy_support import (numpy_to_vtk, numpy_to_vtkIdTypeArray,
-                                    vtk_to_numpy)
 from menpo.shape import TriMesh
 
 
@@ -24,6 +21,8 @@ def trimesh_to_vtk(trimesh):
     ValueError:
         If the input trimesh is not 3D.
     """
+    import vtk
+    from vtk.util.numpy_support import numpy_to_vtk, numpy_to_vtkIdTypeArray
     if trimesh.n_dims != 3:
         raise ValueError('trimesh_to_vtk() only works on 3D TriMesh instances')
 
@@ -62,6 +61,7 @@ def trimesh_from_vtk(vtk_mesh):
     trimesh : :map:`TriMesh`
         A menpo :map:`TriMesh` representation of the VTK mesh data
     """
+    from vtk.util.numpy_support import vtk_to_numpy
     points = vtk_to_numpy(vtk_mesh.GetPoints().GetData())
     trilist = vtk_to_numpy(vtk_mesh.GetPolys().GetData())
     return TriMesh(points, trilist=trilist.reshape([-1, 4])[:, 1:])
@@ -79,6 +79,7 @@ class VTKClosestPointLocator(object):
         efficient future lookups.
     """
     def __init__(self, vtk_mesh):
+        import vtk
         cell_locator = vtk.vtkCellLocator()
         cell_locator.SetDataSet(vtk_mesh)
         cell_locator.BuildLocator()

--- a/setup.py
+++ b/setup.py
@@ -20,5 +20,5 @@ setup(name='menpo3d',
       packages=find_packages(),
       package_data={'menpo3d': ['data/*']},
       install_requires=install_requires,
-      tests_require=['nose', 'mock']
+      tests_require=['nose', 'mock==1.0.1']
 )


### PR DESCRIPTION
VTK module has induced this issue once again: https://github.com/menpo/landmarkerio-server/issues/12

Tucking VTK imports inside functions to prevent a huge import chain.