### PR TITLE
Fix for duplicate vertices in .obj importing

### DIFF
--- a/menpo3d/io/input/mesh/base.py
+++ b/menpo3d/io/input/mesh/base.py
@@ -189,12 +189,15 @@ def obj_importer(filepath, asset=None, texture_resolver=None, **kwargs):
     import vtk
     from vtk.util.numpy_support import vtk_to_numpy
 
+    cleaner = vtk.vtkCleanPolyData()
+
     obj_importer = vtk.vtkOBJReader()
     obj_importer.SetFileName(str(filepath))
-    obj_importer.Update()
+    cleaner.SetInputConnection(obj_importer.GetOutputPort())
+    cleaner.Update()
 
     # Get the output
-    polydata = obj_importer.GetOutput()
+    polydata = cleaner.GetOutput()
 
     # We must have point data!
     points = vtk_to_numpy(polydata.GetPoints().GetData()).astype(np.float)


### PR DESCRIPTION
Resolves #28.  Based off of http://www.vtk.org/gitweb?p=VTK.git;a=blob;f=Examples/Modelling/Cxx/Delaunay3D.cxx, uses vtkCleanPolyData class to remove identical vertices prior to menpo processing.