### PR TITLE
Add support for newer scikit-sparse namespace

### DIFF
--- a/menpo3d/correspond/nicp.py
+++ b/menpo3d/correspond/nicp.py
@@ -5,7 +5,13 @@ from menpo.transform import Translation, UniformScale
 from menpo3d.vtkutils import trimesh_to_vtk, VTKClosestPointLocator
 
 try:
-    from scikits.sparse.cholmod import cholesky_AAt
+    
+    try:
+        # First try the newer scikit-sparse namespace
+        from sksparse.cholmod import cholesky_AAt
+    except ImportError:
+        # Fall back to the older scikits.sparse namespace
+        from scikits.sparse.cholmod import cholesky_AAt
 
     # user has cholesky available - provide a fast solve
     def spsolve(sparse_X, dense_b):


### PR DESCRIPTION
[scikits.sparse](https://pypi.python.org/pypi/scikits.sparse) has changed the package name:
http://pythonhosted.org/scikit-sparse/overview.html

Add support for trying this package first before the older namespace.