### PR TITLE
fix final bcoords tri_indices issue

### DIFF
--- a/menpo3d/rasterize/base.py
+++ b/menpo3d/rasterize/base.py
@@ -70,7 +70,5 @@ def rasterize_shape_image_from_barycentric_coordinate_images(mesh,
 
 def rasterize_mesh(mesh_in_img, image_shape):
     from .cpu import rasterize_barycentric_coordinate_images
-    ti, bc = rasterize_barycentric_coordinate_images(mesh_in_img,
-                                                     image_shape)
-    return rasterize_mesh_from_barycentric_coordinate_images(
-        mesh_in_img, bc, ti)
+    bcs = rasterize_barycentric_coordinate_images(mesh_in_img, image_shape)
+    return rasterize_mesh_from_barycentric_coordinate_images(mesh_in_img, *bcs)

--- a/menpo3d/rasterize/cpu.py
+++ b/menpo3d/rasterize/cpu.py
@@ -148,13 +148,13 @@ def rasterize_barycentric_coordinate_images(mesh, image_shape):
     yx, bcoords, tri_indices = rasterize_barycentric_coordinates(mesh,
                                                                  image_shape)
 
-    tri_index_img = np.zeros((1, h, w), dtype=int)
-    bcoord_img = np.zeros((3, h, w))
+    tri_indices_img = np.zeros((1, h, w), dtype=int)
+    bcoords_img = np.zeros((3, h, w))
     mask = np.zeros((h, w), dtype=np.bool)
     mask[yx[:, 0], yx[:, 1]] = True
-    tri_index_img[:, yx[:, 0], yx[:, 1]] = tri_indices
-    bcoord_img[:, yx[:, 0], yx[:, 1]] = bcoords.T
+    tri_indices_img[:, yx[:, 0], yx[:, 1]] = tri_indices
+    bcoords_img[:, yx[:, 0], yx[:, 1]] = bcoords.T
 
     mask = BooleanImage(mask)
-    return (MaskedImage(tri_index_img, mask=mask.copy(), copy=False),
-            MaskedImage(bcoord_img, mask=mask.copy(), copy=False))
+    return (MaskedImage(bcoords_img, mask=mask.copy(), copy=False),
+            MaskedImage(tri_indices_img, mask=mask.copy(), copy=False))


### PR DESCRIPTION
One of the goals of #40 was to standardise on using `bcoords, tri_indicies` always in this order (as return types from and positional arguments to functions concerned with barycentric coordinate mappings).

Unfortunately one case was missed. This is a hotfix to catch that last edge case.