### PR TITLE
add importer_for_lsfm_models

### DIFF
--- a/menpo3d/io/__init__.py
+++ b/menpo3d/io/__init__.py
@@ -2,5 +2,6 @@ from .input import (import_builtin_asset, mesh_paths,
                     import_landmark_file, import_landmark_files,
                     data_path_to, data_dir_path, ls_builtin_assets,
                     landmark_file_paths, import_mesh, import_meshes,
-                    register_landmark_importer, register_mesh_importer)
+                    register_landmark_importer, register_mesh_importer,
+                    import_lsfm_model)
 from .output import export_landmark_file, export_mesh, export_textured_mesh

--- a/menpo3d/io/input/__init__.py
+++ b/menpo3d/io/input/__init__.py
@@ -4,4 +4,5 @@ from .base import (import_builtin_asset, mesh_paths,
                    menpo3d_data_dir_path as data_dir_path,
                    menpo3d_ls_builtin_assets as ls_builtin_assets,
                    landmark_file_paths, import_mesh, import_meshes,
-                   register_landmark_importer, register_mesh_importer)
+                   register_landmark_importer, register_mesh_importer,
+                   import_lsfm_model)

--- a/menpo3d/io/input/base.py
+++ b/menpo3d/io/input/base.py
@@ -10,7 +10,7 @@ from menpo.io.input.base import (glob_with_suffix, _import_glob_lazy_list,
                                  _register_importer)
 from menpo.io.input import same_name, image_paths
 from menpo3d.base import menpo3d_src_dir_path
-from .extensions import mesh_types, mesh_landmark_types
+from .extensions import mesh_types, mesh_landmark_types, lsfm_types
 
 
 def mesh_paths(pattern):
@@ -225,6 +225,24 @@ def import_landmark_files(pattern, max_landmarks=None, shuffle=False,
                                   shuffle=shuffle, as_generator=as_generator,
                                   verbose=verbose)
 
+
+def import_lsfm_model(filepath):
+    r"""Import a LSFM Morphable Model
+
+
+    Parameters
+    ----------
+    filepath : `str`
+        A relative or absolute filepath to a LSFM model mat file.
+
+    Returns
+    -------
+    :map:`PCAModel`
+        The 3DMM contained in the LSFM mat file.
+
+    """
+    return _import(filepath, lsfm_types,
+                   landmark_resolver=None)
 
 import_builtin_asset = BuiltinAssets(_menpo3d_import_builtin_asset)
 

--- a/menpo3d/io/input/extensions.py
+++ b/menpo3d/io/input/extensions.py
@@ -3,6 +3,7 @@ from .mesh import (wrl_importer, mjson_importer, obj_importer,
                    stl_importer, ply_importer)
 from .landmark_mesh import (bnd_importer, lan_importer, lm3_importer,
                             pts_mesh_importer)
+from .lsfm import lsfm_model_importer
 
 # TODO: Add PLY (ASCII and binary) and OFF importers
 mesh_types = {'.obj': obj_importer,
@@ -16,3 +17,7 @@ mesh_landmark_types = {'.pts3': pts_mesh_importer,
                        '.lan': lan_importer,
                        '.bnd': bnd_importer,
                        '.ljson': ljson_importer}
+
+lsfm_types = {
+    '.mat': lsfm_model_importer
+}

--- a/menpo3d/io/input/lsfm.py
+++ b/menpo3d/io/input/lsfm.py
@@ -6,5 +6,6 @@ from menpo.shape import TriMesh
 def lsfm_model_importer(path, **kwargs):
     m = loadmat(str(path))
     mean = TriMesh(m['mean'].reshape([-1, 3]), trilist=m['trilist'])
-    return PCAModel.init_from_components(m['components'].T, m['eigenvalues'],
+    return PCAModel.init_from_components(m['components'].T,
+                                         m['eigenvalues'].ravel(),
                                          mean, m['n_training_samples'], True)

--- a/menpo3d/io/input/lsfm.py
+++ b/menpo3d/io/input/lsfm.py
@@ -1,0 +1,10 @@
+from scipy.io import loadmat
+from menpo.model import PCAModel
+from menpo.shape import TriMesh
+
+
+def lsfm_model_importer(path, **kwargs):
+    m = loadmat(str(path))
+    mean = TriMesh(m['mean'].reshape([-1, 3]), trilist=m['trilist'])
+    return PCAModel.init_from_components(m['components'].T, m['eigenvalues'],
+                                         mean, m['n_training_samples'], True)


### PR DESCRIPTION
Adds an importer for the LSFM model file format, as specificed here:

https://github.com/menpo/lsfm/blob/master/MODELS.md