### PR TITLE
adapt for menpo 0.8 (landmark changes)

### DIFF
--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -11,7 +11,7 @@ requirements:
 
   run:
     - python
-    - menpo >=0.7.6,<0.8
+    - menpo 0.8.*
     - cyrasterize 0.3.*
     - mayavi 4.5.*
     - scikit-sparse 0.3.*  # [linux]

--- a/menpo3d/correspond/nicp.py
+++ b/menpo3d/correspond/nicp.py
@@ -143,7 +143,7 @@ def active_non_rigid_icp(model, target, eps=1e-3,
 
         shape_model = ShapeModel(model)
         source_lms = model_mean_landmarks
-        target_lms = target.landmarks[landmark_group].lms
+        target_lms = target.landmarks[landmark_group]
         model_lms_index = model_mean.distance_to(source_lms).argmin(axis=0)
         shape_model_lms = shape_model.mask_points(model_lms_index)
 
@@ -212,8 +212,8 @@ def non_rigid_icp_generator(source, target, eps=1e-3,
             print("'{}' landmarks will be used as "
                   "a landmark constraint.".format(landmark_group))
             print("performing similarity alignment using landmarks")
-        lm_align = AlignmentSimilarity(source.landmarks[landmark_group].lms,
-                                       target.landmarks[landmark_group].lms).as_non_alignment()
+        lm_align = AlignmentSimilarity(source.landmarks[landmark_group],
+                                       target.landmarks[landmark_group]).as_non_alignment()
         source = lm_align.apply(source)
 
     # Scale factors completely change the behavior of the algorithm - always
@@ -317,8 +317,8 @@ def non_rigid_icp_generator(source, target, eps=1e-3,
 
     if landmark_group is not None:
         source_lm_index = source.distance_to(
-            source.landmarks[landmark_group].lms).argmin(axis=0)
-        target_lms = target.landmarks[landmark_group].lms
+            source.landmarks[landmark_group]).argmin(axis=0)
+        target_lms = target.landmarks[landmark_group]
         U_L = target_lms.points
         n_landmarks = target_lms.n_points
         lm_mask = np.in1d(row, source_lm_index)

--- a/menpo3d/extractimage.py
+++ b/menpo3d/extractimage.py
@@ -93,5 +93,5 @@ def extract_per_vertex_features(mesh, image, feature_f, diagonal_range=None):
         image = image.rescale_landmarks_to_diagonal_range(diagonal_range,
                                                           group='mesh_2d')
     feature_image = feature_f(image)
-    return extract_per_vertex_colour(feature_image.landmarks['mesh_2d'].lms,
+    return extract_per_vertex_colour(feature_image.landmarks['mesh_2d'],
                                      feature_image)

--- a/menpo3d/io/test/io_input_test.py
+++ b/menpo3d/io/test/io_input_test.py
@@ -56,10 +56,10 @@ def test_json_landmarks_bunny():
     lms = mesh.landmarks['LJSON']
     labels = {'reye', 'mouth', 'nose', 'leye'}
     assert(len(labels - set(lms.labels)) == 0)
-    assert_allclose(lms['leye'].points, bunny_leye, atol=1e-7)
-    assert_allclose(lms['reye'].points, bunny_reye, atol=1e-7)
-    assert_allclose(lms['nose'].points, bunny_nose, atol=1e-7)
-    assert_allclose(lms['mouth'].points, bunny_mouth, atol=1e-7)
+    assert_allclose(lms.with_labels('leye').points, bunny_leye, atol=1e-7)
+    assert_allclose(lms.with_labels('reye').points, bunny_reye, atol=1e-7)
+    assert_allclose(lms.with_labels('nose').points, bunny_nose, atol=1e-7)
+    assert_allclose(lms.with_labels('mouth').points, bunny_mouth, atol=1e-7)
 
 
 def test_custom_landmark_logic_bunny():
@@ -73,18 +73,18 @@ def test_custom_landmark_logic_bunny():
     lms = mesh.landmarks['no_nose']
     labels = {'reye', 'mouth', 'leye'}
     assert(len(set(lms.labels) - labels) == 0)
-    assert_allclose(lms['leye'].points, bunny_leye, atol=1e-7)
-    assert_allclose(lms['reye'].points, bunny_reye, atol=1e-7)
-    assert_allclose(lms['mouth'].points, bunny_mouth, atol=1e-7)
+    assert_allclose(lms.with_labels('leye').points, bunny_leye, atol=1e-7)
+    assert_allclose(lms.with_labels('reye').points, bunny_reye, atol=1e-7)
+    assert_allclose(lms.with_labels('mouth').points, bunny_mouth, atol=1e-7)
 
     assert('full_set' in mesh.landmarks.group_labels)
     lms = mesh.landmarks['full_set']
     labels = {'reye', 'mouth', 'nose', 'leye'}
     assert(len(set(lms.labels) - labels) == 0)
-    assert_allclose(lms['leye'].points, bunny_leye, atol=1e-7)
-    assert_allclose(lms['reye'].points, bunny_reye, atol=1e-7)
-    assert_allclose(lms['nose'].points, bunny_nose, atol=1e-7)
-    assert_allclose(lms['mouth'].points, bunny_mouth, atol=1e-7)
+    assert_allclose(lms.with_labels('leye').points, bunny_leye, atol=1e-7)
+    assert_allclose(lms.with_labels('reye').points, bunny_reye, atol=1e-7)
+    assert_allclose(lms.with_labels('nose').points, bunny_nose, atol=1e-7)
+    assert_allclose(lms.with_labels('mouth').points, bunny_mouth, atol=1e-7)
 
 
 def test_custom_landmark_logic_None_bunny():
@@ -98,10 +98,10 @@ def test_json_landmarks_bunny_direct():
     lms = mio.import_landmark_file(mio.data_path_to('bunny.ljson'))
     labels = {'reye', 'mouth', 'nose', 'leye'}
     assert(len(labels - set(lms.labels)) == 0)
-    assert_allclose(lms['leye'].points, bunny_leye, atol=1e-7)
-    assert_allclose(lms['reye'].points, bunny_reye, atol=1e-7)
-    assert_allclose(lms['nose'].points, bunny_nose, atol=1e-7)
-    assert_allclose(lms['mouth'].points, bunny_mouth, atol=1e-7)
+    assert_allclose(lms.with_labels('leye').points, bunny_leye, atol=1e-7)
+    assert_allclose(lms.with_labels('reye').points, bunny_reye, atol=1e-7)
+    assert_allclose(lms.with_labels('nose').points, bunny_nose, atol=1e-7)
+    assert_allclose(lms.with_labels('mouth').points, bunny_mouth, atol=1e-7)
 
 
 def test_ls_builtin_assets():

--- a/menpo3d/morphablemodel/fitter.py
+++ b/menpo3d/morphablemodel/fitter.py
@@ -101,7 +101,7 @@ class MMFitter(object):
         feature_image = self.holistic_features(tmp_image)
 
         # Get final transformed landmarks
-        new_initial_shape = feature_image.landmarks['__initial_shape'].lms
+        new_initial_shape = feature_image.landmarks['__initial_shape']
 
         # Now we have introduced an affine transform that consists of the image
         # rescaled based on the diagonal, as well as potential rescale

--- a/menpo3d/vtk_test.py
+++ b/menpo3d/vtk_test.py
@@ -22,7 +22,7 @@ def test_trimesh_to_vtk_fails_on_2d_mesh():
 
 def test_barycentric_rebuild_returns_same_as_snapped_points():
     mesh = menpo3d.io.import_builtin_asset.bunny_obj()
-    lms = mesh.landmarks[None].lms
+    lms = mesh.landmarks[None]
     bc = mesh.barycentric_coordinates_of_pointcloud(lms)
     recon_lms = mesh.project_barycentric_coordinates(*bc)
     direct_recon_lms = mesh.snap_pointcloud_to_surface(lms)[0]

--- a/setup.py
+++ b/setup.py
@@ -73,8 +73,7 @@ cython_modules = [
 ]
 cython_exts = cythonize(cython_modules, quiet=True)
 
-install_requires = ['menpo>=0.7.6,<0.8',
-                    'cyrasterize>=0.3,<0.4',
+install_requires = ['menpo>=0.8,<0.9',
                     'mayavi>=4.5.0']
 
 setup(name='menpo3d',


### PR DESCRIPTION
This adapts menpo3d to use the simplified landmarks model introduced in menpo 0.8.

It requires https://github.com/menpo/menpo/pull/675 to be merged before it can be merged.