### PR TITLE
Fix rasterizer fragment shader layout

### DIFF
--- a/menpo3d/rasterize/opengl.py
+++ b/menpo3d/rasterize/opengl.py
@@ -128,6 +128,7 @@ class TexturePassthroughProgram(BasePassthroughProgram):
         )
         self.texture = None
         self._texture_shape = None
+        self._pixels_ref = None
 
     def __del__(self):
         super().__del__()
@@ -145,9 +146,14 @@ class TexturePassthroughProgram(BasePassthroughProgram):
         shape = pixels.shape[:2][::-1]
         if self._texture_shape is None or self._texture_shape != shape:
             self._texture_shape = shape
+            # Note this keeps the texture alive and so uses lots of memory for large textures
+            self._pixels_ref = pixels
             self.texture = self.context.texture(
                 size=shape, components=3, data=pixels.tobytes(), dtype="f4"
             )
+        elif self._pixels_ref is not pixels:
+            assert self.texture is not None
+            self.texture.write(pixels.tobytes())
 
     def create_vao(self, mesh, per_vertex_f3v):
         """

--- a/menpo3d/rasterize/shaders/per_vertex/passthrough.frag
+++ b/menpo3d/rasterize/shaders/per_vertex/passthrough.frag
@@ -2,8 +2,8 @@
 uniform sampler2D Texture;
 in vec3 v_color;
 in vec3 v_f3v;
-out vec4 f_color;
-out vec3 f_f3v;
+layout(location = 0) out vec4 f_color;
+layout(location = 1) out vec3 f_f3v;
 
 void main() {
    f_color = vec4(v_color, 1.0);

--- a/menpo3d/rasterize/shaders/texture/passthrough.frag
+++ b/menpo3d/rasterize/shaders/texture/passthrough.frag
@@ -2,8 +2,8 @@
 uniform sampler2D Texture;
 in vec2 v_text;
 in vec3 v_f3v;
-out vec4 f_color;
-out vec3 f_f3v;
+layout(location = 0) out vec4 f_color;
+layout(location = 1) out vec3 f_f3v;
 
 void main() {
    // Note the Y texture coordinates are flipped


### PR DESCRIPTION
Merge after #72 

This fixes rendering on headless servers by specifcally setting the layout location for the fragment shader outputs. Apparently this is implementation dependent otherwise and it seems using llvmpipe (osmesa) binds the outputs in a different order which causes rendering errors. This is now fixed.