### PR TITLE
Properly acquire OpenGL context before rendering

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,3 +61,4 @@ menpo3d.iml
 *.mat
 
 .ipynb_checkpoints
+.DS_Store

--- a/conda/meta.yaml
+++ b/conda/meta.yaml
@@ -21,7 +21,7 @@ requirements:
     - {{ pin_compatible('numpy') }}
     - menpo >=0.9.0,<0.12.0
     - mayavi >=4.7.0
-    - moderngl
+    - moderngl >=5.6.0
     - pyqt >=5.12
 
 test:

--- a/setup.py
+++ b/setup.py
@@ -111,7 +111,7 @@ cython_exts = cythonize(cython_modules, quiet=True)
 
 version, cmdclass = get_version_and_cmdclass("menpo3d")
 
-install_requires = ["menpo>=0.9.0,<0.12.0", "mayavi>=4.7.0", "moderngl>=5.5.*,<6.0"]
+install_requires = ["menpo>=0.9.0,<0.12.0", "mayavi>=4.7.0", "moderngl>=5.6.*,<6.0"]
 
 setup(
     name="menpo3d",


### PR DESCRIPTION
Not acquiring the context properly mean that crashes were common
particularly when VTK is used in the same Python process. This
should help prevent that.

This relies on a 5.6.x feature of moderngl so the deps were
updated accordingly