### PR TITLE
Fix inline display of meshes

### DIFF
--- a/menpo3d/visualize/viewmayavi.py
+++ b/menpo3d/visualize/viewmayavi.py
@@ -163,7 +163,7 @@ class MayaviRenderer(Renderer):
             The size of the image created (unless magnification is set,
             in which case it is the size of the window used for rendering). If
             ``None``, then the figure size is used.
-        magnification :	`double` or ``'auto'``, optional
+        magnification : `double` or ``'auto'``, optional
             The magnification is the scaling between the pixels on the screen,
             and the pixels in the file saved. If you do not specify it, it will
             be calculated so that the file is saved with the specified size.
@@ -279,6 +279,11 @@ class MayaviRenderer(Renderer):
         _gui.set_busy(busy=True)
         _gui.set_busy(busy=orig_val)
         _gui.process_events()
+
+    def _ipython_display_(self):
+        from IPython.display import display
+
+        return display(self.figure)
 
 
 class MayaviVectorViewer3d(MayaviRenderer):

--- a/menpo3d/visualize/viewmayavi.py
+++ b/menpo3d/visualize/viewmayavi.py
@@ -361,12 +361,11 @@ class MayaviPointGraphViewer3d(MayaviRenderer):
             )
             # Connect them
             src.mlab_source.dataset.lines = self.edges
-            # The stripper filter cleans up connected lines
-            lines = mlab.pipeline.stripper(src)
+            src.update()
 
             # Finally, display the set of lines
             mlab.pipeline.surface(
-                lines,
+                src,
                 figure=self.figure,
                 opacity=alpha,
                 line_width=line_width,


### PR DESCRIPTION
Add ipython_display override to the mesh viewer to make mayavi inline viewing work:

```
%matplotlib inline
from mayavi import mlab
mlab.init_notebook(backend="ipy")

menpo3d.io.import_builtin_asset.james_obj().view()
```