### PR TITLE
Drop Python 3.6 builds - add Python 3.10

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,9 +4,6 @@ workflows:
   version: 2
   test:
     jobs:
-      - linux_python_3.6:
-          context:
-            - menpo
       - linux_python_3.7:
           context:
             - menpo
@@ -17,6 +14,9 @@ workflows:
           filters:
             tags:
               only: /.*/
+          context:
+            - menpo
+      - linux_python_3.10:
           context:
             - menpo
 
@@ -36,11 +36,6 @@ template: &linux_template
           ~/miniconda/bin/python condaci.py build ./conda
 
 jobs:
-  linux_python_3.6:
-    <<: *linux_template
-    environment:
-      CONDACI_PYPI_SDIST_UPLOAD_PY_VER: 3.9
-      PYTHON_VERSION: 3.6
   linux_python_3.7:
     <<: *linux_template
     environment:
@@ -56,3 +51,8 @@ jobs:
     environment:
       CONDACI_PYPI_SDIST_UPLOAD_PY_VER: 3.9
       PYTHON_VERSION: 3.9
+  linux_python_3.10:
+    <<: *linux_template
+    environment:
+      CONDACI_PYPI_SDIST_UPLOAD_PY_VER: 3.10
+      PYTHON_VERSION: 3.10


### PR DESCRIPTION
Python 3.6 builds are failing  and EOL was 23 Dec 2021 -> https://endoflife.date/python 

Python 3.10 was released almost a year ago so support should be OK